### PR TITLE
Remove rvalue references to emit_signal

### DIFF
--- a/include/app.hpp
+++ b/include/app.hpp
@@ -66,7 +66,7 @@ namespace chroma {
             }
 
             template<typename... A>
-            void emit_signal(const std::string &name, A&&... args) {
+            void emit_signal(const std::string &name, A... args) {
                 std::size_t hash = typeid(void(*)(std::decay_t<A>...)).hash_code();
                 if (!signals.contains(name)) {
                     return;

--- a/src/menu/newitem.cpp
+++ b/src/menu/newitem.cpp
@@ -39,7 +39,7 @@ namespace chroma {
 
             if (ImGui::Button("OK", ImVec2(140, 0))) {
                 // Create new file with specified width and height
-                App::get_instance()->emit_signal("create_canvas_requested", w, h);
+                App::get_instance()->emit_signal<uint32_t, uint32_t>("create_canvas_requested", w, h);
                 ImGui::CloseCurrentPopup();
             }
             ImGui::SetItemDefaultFocus();


### PR DESCRIPTION
Remove rvalue references to emit_signal in app to force the type of arguments